### PR TITLE
docs: improve installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,24 +9,9 @@ This plugin contains rule exclusions to fix false positives when using iRedMail'
 - CRS Version 4.0 or newer
 - ModSecurity compatable Web Application Firewall
 
-## How to install the plugin
-1. Copy and paste the files ``iredadmin-rule-exclusions-before.conf`` and ``iredadmin-rule-exclusions-config.conf`` into your CRS plugins folder.
+## Installation
 
-2. Create two wildcards includes after ``crs-setup.conf`` but before loading CRS rules. Create the ``*-config.conf`` includes first, followed by the ``*-before.conf`` includes as shown in the code block below (This only needs to be done once, after that any plugins placed within the plugins folder will automatically be activated).
-
-3. Then reload your WAF to apply the new changes (Restart for Nginx ModSec users)
-
-```
-Include /path/to/coreruleset/modsecurity.conf
-Include /path/to/coreruleset/crs-setup.conf
-
-Include /path/to/coreruleset/plugins/*-config.conf
-Include /path/to/coreruleset/plugins/*-before.conf
-
-Include /path/to/coreruleset/rules/*.conf
-```
-
-You can also refer to official CRS documentation on how to install a plugin https://coreruleset.org/docs/concepts/plugins/#how-to-install-a-plugin
+For full and up to date instructions on installing plugins, please refer to [How to Install a Plugin](https://coreruleset.org/docs/concepts/plugins/#how-to-install-a-plugin) in the official CRS documentation.
 
 ## Disabling the plugin
 The plugin can be disabled by uncommenting rule 9521000 inside ``plugins/iredadmin-rule-exclusions-config.conf`` or by removing the includes for this plugin.


### PR DESCRIPTION
Replacing installation instructions with a link to official CRS documentation on installing a plugin. This way, I won't have to update the installation instructions if installation methods change in the future.