### PR TITLE
fix: false positive on greylisting page

### DIFF
--- a/plugins/iredadmin-rule-exclusions-before.conf
+++ b/plugins/iredadmin-rule-exclusions-before.conf
@@ -135,6 +135,22 @@ SecRule REQUEST_FILENAME "@rx ^/iredadmin/profile/(?:user|admin)/password/[^/]+$
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:newpw,\
     ver:'iredadmin-rule-exclusions-plugin/1.0.1'"
 
+    
+#
+# [ System operations ]
+#
+
+# Greylist administration may contain domains and newlines that trigger rule
+# 932370 (RCE) falsely
+SecRule REQUEST_FILENAME "@streq /iredadmin/system/greylisting" \
+    "id:9521170,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveTargetById=932370;ARGS:whitelist_domains,\
+    ver:'iredadmin-rule-exclusions-plugin/1.0.1'"
+
 #
 # [ Disclaimers ]
 #

--- a/tests/regression/iredadmin-rule-exclusions-plugin/9521170.yaml
+++ b/tests/regression/iredadmin-rule-exclusions-plugin/9521170.yaml
@@ -1,0 +1,27 @@
+---
+meta:
+  author: "Steve Kerrison"
+  description: "iRedAdmin Rule Exclusions Plugin"
+rule_id: 9521170
+tests:
+  - test_id: 1
+    desc: |
+      Updating domain whitelist in greylisting system configuration.
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: iRedAdmin rule exclusions plugin
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Content-Type: application/x-www-form-urlencoded
+          port: 80
+          method: POST
+          uri: /iredadmin/system/greylisting
+          data: >-
+            csrf_token=9sdXg3y655dLp7NdZ57aXd432QFNRws3&greylisting=enable&whitelist_domains=amazon.com%0D%0Aaol.com%0D%0Amicrosoft.com
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids:
+              - 932370

--- a/tests/regression/iredadmin-rule-exclusions-plugin/9521170.yaml
+++ b/tests/regression/iredadmin-rule-exclusions-plugin/9521170.yaml
@@ -5,8 +5,7 @@ meta:
 rule_id: 9521170
 tests:
   - test_id: 1
-    desc: |
-      Updating domain whitelist in greylisting system configuration.
+    desc: Updating domain whitelist in greylisting system configuration.
     stages:
       - input:
           dest_addr: 127.0.0.1
@@ -23,5 +22,4 @@ tests:
           version: HTTP/1.1
         output:
           log:
-            no_expect_ids:
-              - 932370
+            no_expect_ids: [932370]


### PR DESCRIPTION
The domain whitelist ("Do not apply greylisting on emails sent from domains listed") in the greylisting feature of iRedAdmin may contain a `\r\n`-separated list of domains, some of which may end in `.com`. This triggers rule `932370` which looks for (amongst other things) newlines and possible executable file references (including `com` files) for RCE - Windows Command Injection.

Please advise if the exclusion rule ID is appropriate and I would appreciate your advice/instruction regarding the unit and integration testing.

Thanks!