### PR TITLE
feat: add support for custom base-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For full and up to date instructions on how to conditionally enable/disable this
 
 ### Configuration
 
-By default, iRedAdmin's base URL is set to `/iredadmin/` which is also the default base URL supported by this plugin. If you've changed iRedAdmin's base URL, then this plugin can be configured to use a different base url such as `/admin/` by editing rule `9519001` in `iredadmin-rule-exclusions-config.conf`.
+By default, iRedAdmin's base URL is set to `/iredadmin/` which is also the default base URL supported by this plugin. If you've changed iRedAdmin's base URL, then this plugin can be configured to use a different base url such as `/admin/` or a random string to obfuscate iRedAdmin's location by editing rule `9519001` in `iredadmin-rule-exclusions-config.conf`.
 
 > [!WARNING]
 > It's not recommended to set the base url to `/`, which means the plugin will run on all URL paths. Most iRedMail installations will include other web applications such as RoundCube or SOGo hosted under the same domain name, in such cases if a bypass is found in this plugin, then other web apps unrelated to iRedAdmin will be impacted.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ For full and up to date instructions on installing plugins, please refer to [How
 
 For full and up to date instructions on how to conditionally enable/disable this plugin on a multisite environment, please refer to [Conditionally enable plugins for multi-application environments](https://coreruleset.org/docs/concepts/plugins/#conditionally-enable-plugins-for-multi-application-environments) in the official CRS documentation.
 
+### Configuration
+
+By default, iRedAdmin's base URL is set to `/iredadmin/` which is also the default base URL supported by this plugin. If you've changed iRedAdmin's base URL, then this plugin can be configured to use a different base url such as `/admin/` by editing rule `9519001` in `iredadmin-rule-exclusions-config.conf`.
+
+> [!WARNING]
+> It's not recommended to set the base url to `/`, which means the plugin will run on all URL paths. Most iRedMail installations will include other web applications such as RoundCube or SOGo hosted under the same domain name, in such cases if a bypass is found in this plugin, then other web apps unrelated to iRedAdmin will be impacted.
+
 ## Disabling the plugin
 The plugin can be disabled by uncommenting rule 9521000 inside ``plugins/iredadmin-rule-exclusions-config.conf`` or by removing the includes for this plugin.
 

--- a/plugins/iredadmin-rule-exclusions-before.conf
+++ b/plugins/iredadmin-rule-exclusions-before.conf
@@ -16,12 +16,22 @@
 # Generic rule to disable plugin
 SecRule TX:iredadmin-rule-exclusions-plugin "@eq 0" "id:9521010,phase:1,pass,nolog,ctl:ruleRemoveById=9521100-9521999"
 
+# Set default iRedAdmin base-url to `/iredadmin/` if unconfigured
+SecRule &TX:iredadmin-rule-exclusions-base-url "@eq 0" "id:9521011,phase:1,pass,nolog,setvar:'tx.iredadmin-rule-exclusions-base-url=/iredadmin/'"
+
+# Disable the plugin if the URL path is doesn't start with iRedAdmin path
+SecRule REQUEST_FILENAME "!@beginsWith %{tx.iredadmin-rule-exclusions-base-url}" "id:9521012,phase:1,pass,nolog,ctl:ruleRemoveById=9521100-9521999"
+
+# Base URLs without a trailing slash may lead to directory traversal being abused to bypass CRS
+SecRule TX:iredadmin-rule-exclusions-base-url "!@endsWith /" "id:9521013,phase:1,deny,log,auditlog,status:500,\
+    msg:'iRedAdmin rule-exclusions plugin base-url is configured without a trailing slash, a path traversal attack (../) could be used to activate this plugin on non-iredadmin web apps.'"
+
 #
 # [ General rule exclusions ]
 #
 
 # iRedAdmin displays domain names inside the request uri, domains most commonly end in .com which triggers 920440.
-SecRule REQUEST_FILENAME "@rx ^/iredadmin/.+\.(?:com|inc)$" \
+SecRule REQUEST_FILENAME "@rx \.(?:com|inc)$" \
     "id:9521110,\
     phase:1,\
     pass,\
@@ -35,7 +45,7 @@ SecRule REQUEST_FILENAME "@rx ^/iredadmin/.+\.(?:com|inc)$" \
 #
 
 # logging into iRedAdmin admin panel
-SecRule REQUEST_FILENAME "@streq /iredadmin/login" \
+SecRule REQUEST_FILENAME "@endsWith /login" \
     "id:9521130,\
     phase:1,\
     pass,\
@@ -52,7 +62,7 @@ SecRule REQUEST_FILENAME "@streq /iredadmin/login" \
 #
 
 # Creating a new iRedMail user
-SecRule REQUEST_FILENAME "@rx ^/iredadmin/create/user/[^/]+$" \
+SecRule REQUEST_FILENAME "@rx /create/user/[^/]+$" \
     "id:9521150,\
     phase:1,\
     pass,\
@@ -64,7 +74,7 @@ SecRule REQUEST_FILENAME "@rx ^/iredadmin/create/user/[^/]+$" \
     ver:'iredadmin-rule-exclusions-plugin/1.0.1'"
 
 # When making changes to an existing iRedMail user or Administrator
-SecRule REQUEST_FILENAME "@rx ^/iredadmin/profile/user/general/[^/]+$" \
+SecRule REQUEST_FILENAME "@rx /profile/user/general/[^/]+$" \
     "id:9521151,\
     phase:1,\
     pass,\
@@ -79,7 +89,7 @@ SecRule REQUEST_FILENAME "@rx ^/iredadmin/profile/user/general/[^/]+$" \
     ver:'iredadmin-rule-exclusions-plugin/1.0.1'"
 
 # Adding a new iRedMail Administrator
-SecRule REQUEST_FILENAME "@streq /iredadmin/create/admin" \
+SecRule REQUEST_FILENAME "@endsWith /create/admin" \
     "id:9521152,\
     phase:1,\
     pass,\
@@ -92,7 +102,7 @@ SecRule REQUEST_FILENAME "@streq /iredadmin/create/admin" \
     ver:'iredadmin-rule-exclusions-plugin/1.0.1'"
 
 # When changing an existing iRedMail Admin/User's password
-SecRule REQUEST_FILENAME "@rx ^/iredadmin/profile/(?:user|admin)/password/[^/]+$" \
+SecRule REQUEST_FILENAME "@rx /profile/(?:user|admin)/password/[^/]+$" \
     "id:9521153,\
     phase:1,\
     pass,\
@@ -110,7 +120,7 @@ SecRule REQUEST_FILENAME "@rx ^/iredadmin/profile/(?:user|admin)/password/[^/]+$
 
 # Greylist administration may contain domains and newlines that trigger rule
 # 932370 (RCE) falsely
-SecRule REQUEST_FILENAME "@streq /iredadmin/system/greylisting" \
+SecRule REQUEST_FILENAME "@endsWith /system/greylisting" \
     "id:9521170,\
     phase:1,\
     pass,\
@@ -125,7 +135,7 @@ SecRule REQUEST_FILENAME "@streq /iredadmin/system/greylisting" \
 
 # Only plaintext disclaimer messages are accepted, so some common
 # false positive rules have been disabled instead of disabling CRS completely
-SecRule REQUEST_FILENAME "@rx ^/iredadmin/profile/domain/general/[^/]+$" \
+SecRule REQUEST_FILENAME "@rx /profile/domain/general/[^/]+$" \
     "id:9521180,\
     phase:1,\
     pass,\

--- a/plugins/iredadmin-rule-exclusions-config.conf
+++ b/plugins/iredadmin-rule-exclusions-config.conf
@@ -34,10 +34,26 @@
 #
 # Uncomment to disable this plugin
 #
-#SecRule &TX:iredadmin-rule-exclusions-plugin "@eq 0" \
-#    "id:9521000,\
-#    phase:1,\
-#    pass,\
-#    nolog,\
-#    ver:'iredadmin-rule-exclusions-plugin/1.0.1',\
-#    setvar:'tx.iredadmin-rule-exclusions-plugin=0'"
+# SecRule &TX:iredadmin-rule-exclusions-plugin "@eq 0" \
+#     "id:9521000,\
+#     phase:1,\
+#     pass,\
+#     nolog,\
+#     ver:'iredadmin-rule-exclusions-plugin/1.0.1',\
+#     setvar:'tx.iredadmin-rule-exclusions-plugin=0'"
+
+# By default, iRedAdmin's base URL is set to `/iredadmin/`.
+# It's possible to change the base url to something else like `/admin/`
+# or a random string to obfuscate iRedAdmin's location.
+# By default, this plugin only runs under `/iredadmin/` however this behavior
+# can be changed if iRedAdmin is on a different path.
+# See: https://docs.iredmail.org/iredadmin-pro.custom.base.url.html
+# WARNING: Do not set the base-url to `/`, as that will enable the plugin
+# for all URL paths.
+# SecRule &TX:iredadmin-rule-exclusions-base-url "@eq 0" \
+#     "id:9519001,\
+#     phase:1,\
+#     pass,\
+#     nolog,\
+#     ver:'iredadmin-rule-exclusions-plugin/1.0.1',\
+#     setvar:'tx.iredadmin-rule-exclusions-base-url=/iredadmin/'"

--- a/plugins/iredadmin-rule-exclusions-config.conf
+++ b/plugins/iredadmin-rule-exclusions-config.conf
@@ -45,8 +45,8 @@
 # By default, iRedAdmin's base URL is set to `/iredadmin/`.
 # It's possible to change the base url to something else like `/admin/`
 # or a random string to obfuscate iRedAdmin's location.
-# By default, this plugin only runs under `/iredadmin/` however this behavior
-# can be changed if iRedAdmin is on a different path.
+# By default, this plugin only supports `/iredadmin/` as the base url however,
+# this can be changed if iRedAdmin's base url has been changed.
 # See: https://docs.iredmail.org/iredadmin-pro.custom.base.url.html
 # WARNING: Do not set the base-url to `/`, as that will enable the plugin
 # for all URL paths.

--- a/tests/regression/iredadmin-rule-exclusions-plugin/9521012.yaml
+++ b/tests/regression/iredadmin-rule-exclusions-plugin/9521012.yaml
@@ -1,0 +1,21 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "iRedAdmin Rule Exclusions Plugin: Make sure plugin is not active on non-iredadmin paths"
+rule_id: 9521012
+tests:
+  - test_id: 1
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: iRedAdmin rule exclusions plugin
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          port: 80
+          method: GET
+          uri: /not/iredadmin/foo.com
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [920440]


### PR DESCRIPTION
Adds a configuration variable to allow changing the base url to something other than `/iredadmin/`

closes: https://github.com/EsadCetiner/iredadmin-rule-exclusions-plugin/issues/16